### PR TITLE
Fix idna 2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2020.12.5
 chardet==4.0.0
-idna==3.1
+idna==2.10
 requests==2.25.1
 urllib3==1.26.3


### PR DESCRIPTION
Using idna 2.10 because requests because requests 2.25.1 depends on idna 2.10.